### PR TITLE
Allow setting a host to listen on

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
           "default": 3710,
           "description": "Specifies the port on which the websocket server will start. If you are using multiple VSCode instances, it is best to set this in your workspace settings."
         },
+        "remoteControl.host": {
+          "type": "string",
+          "default": "127.0.0.1",
+          "description": "Specifies the host to which the websocket server will bind."
+        },
         "remoteControl.fallbacks": {
           "type": "array",
           "default": [],


### PR DESCRIPTION
It looks like the default binding in this extension listens on `0.0.0.0`, which (without a firewall) allows anyone on the local network to control your VSCode. I'm not 100% sure, but it appears that way from following from WebSocketServer -> http.listen in Node.

This PR introduces the ability to set the host that the extension listens on, defaulting to `127.0.0.1` for safety.