### PR TITLE
Send back returns if any

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ The text you need to pass to the `websocket` listener is as you can see a string
 
 - `Command`: `<command-id>`
 
+### Passing arguments
+
+to pass additional arguments use
+
+```bash
+echo "{ \"command\": \"command.id.with.arguments\", \"args\": [\"value\"] }" | websocat ws://localhost:3710
+```
+
 ### How do I get the command ID?
 
 To get the command ID, open the `Command Palette` and type `Show all commands`. This will give you a list with all the available commands.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,7 +70,7 @@ const startWebsocketServer = async (
     ws = connection;
 
     if (ws) {
-      ws.addEventListener("message", (event: MessageEvent) => {
+      ws.addEventListener("message", async (event: MessageEvent) => {
         if (onlyWhenInFocus && !vscode.window.state.focused) {
           return;
         }
@@ -110,9 +110,25 @@ const startWebsocketServer = async (
           }
 
           if (args instanceof Array) {
-            vscode.commands.executeCommand(wsData.command, ...args);
+            var response = await vscode.commands.executeCommand(wsData.command, ...args)
+            if (response) {
+              try {
+                ws?.send(JSON.stringify(response));
+              }
+              catch (error) {
+                Logger.error((error as Error).message);
+              }
+            };
           } else {
-            vscode.commands.executeCommand(wsData.command, args);
+            var response = await vscode.commands.executeCommand(wsData.command, args);
+            if (response) {
+              try {
+                ws?.send(JSON.stringify(response));
+              }
+              catch (error) {
+                Logger.error((error as Error).message);
+              }
+            };
           }
         }
       });


### PR DESCRIPTION
- adds support for sending back the return of a task as a json string
- adds documentation on how to pass arguments to the README

To test a command like
```typescript
subscriptions.push(vscode.commands.registerCommand(
    `foo.bar`,
    async (path: string) => {
      return {'path': path };
    }
  ));
```

needs to be registered.
Then the interaction would look like this

```bash
echo "{ \"command\": \"foo.bar\", \"args\": [\"abc\"] }" | websocat ws://localhost:3710
{"path":"abc"}
```