### PR TITLE
package.json: enable openssl-legacy for compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run package",
-    "compile": "webpack",
-    "watch": "webpack --watch",
+    "compile": "NODE_OPTIONS=--openssl-legacy-provider webpack",
+    "watch": "NODE_OPTIONS=--openssl-legacy-provider webpack --watch",
     "package": "webpack --mode production --devtool hidden-source-map",
     "test-compile": "tsc -p ./",
     "test-watch": "tsc -watch -p ./",


### PR DESCRIPTION
otherwise webpack might fail with

library: 'digital envelope routines',
reason: 'unsupported',
code: 'ERR_OSSL_EVP_UNSUPPORTED'

the proposed workaround is to add
NODE_OPTIONS=--openssl-legacy-provider

Tested on Ubuntu 22.04 and Node 20.18